### PR TITLE
Add a User-Agent header to prevent throttling.

### DIFF
--- a/lib/CampfireArchiver.js
+++ b/lib/CampfireArchiver.js
@@ -105,7 +105,8 @@ CampfireArchiver.prototype.getJson = function(url, cb){
   request({
     url: url,
     auth: { user: this.state.token, pass: 'X' },
-    json: true
+    json: true,
+    headers: { 'User-Agent': 'Camfire Archiver' }
   }, function(err, response, body){
     cb(err, body);
   });


### PR DESCRIPTION
37signals appears to throttle requests that do not contain a 
User-Agent header.

This error shows up in the last file downloaded when Campfire Archiver crashes:

```
You have exceeded 50 missing_useragent_header requests in a 
10-second period. Please wait 10 seconds before retrying.
```

Setting a User-Agent header allows for full download.

This fixes jbt/campfire-archive#1
