### PR TITLE
Don't crash if transcript.messages is null

### DIFF
--- a/lib/CampfireArchiver.js
+++ b/lib/CampfireArchiver.js
@@ -242,7 +242,9 @@ CampfireArchiver.prototype.fetchAllTranscripts = function(cb){
 };
 
 CampfireArchiver.prototype.processTranscript = function(transcript){
-  transcript.messages.forEach(this.processTranscriptMessage.bind(this));
+  if (transcript.messages) {
+    transcript.messages.forEach(this.processTranscriptMessage.bind(this));
+  }
 };
 
 CampfireArchiver.prototype.processTranscriptMessage = function(msg){


### PR DESCRIPTION
Not sure why, but in my Campfire account `transcript.messages can` sometimes be null.
